### PR TITLE
Extended Player Copy() to include active weapon

### DIFF
--- a/DemoInfo/Player.cs
+++ b/DemoInfo/Player.cs
@@ -104,7 +104,10 @@ namespace DemoInfo
 			me.FlashDuration = FlashDuration;
 
 			me.Team = Team;
-
+                       
+			me.ActiveWeaponID = ActiveWeaponID;
+                        me.rawWeapons = new Dictionary<int, Equipment>(rawWeapons);
+			
 			me.HasDefuseKit = HasDefuseKit;
 			me.HasHelmet = HasHelmet;
 


### PR DESCRIPTION
Hey,

I came across a problem using the library. After saving multiple player copies for later analysis, accessing the weapon would always yield an exception. This is because `rawWeapons` and `ActiveWeaponID` are not copied when calling `Copy()` on the player object.

Changed code accordingly, please verify code formatting before merging. This was the cleanest way formatting I could get it to, but I'm not happy with it.