### PR TITLE
Inventory events

### DIFF
--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -589,8 +589,8 @@ namespace DemoInfo
 						RaisePlayerBind(bind);
 					}
 
-					while (p.newWeapons.Count > 0){
-						var weapon = p.newWeapons.Dequeue();
+					while (p.NewWeapons.Count > 0){
+						var weapon = p.NewWeapons.Dequeue();
 						if (weapon.Weapon != EquipmentElement.Knife) { 
 							PickupWeaponEventArgs pickupweapon = new PickupWeaponEventArgs();
 							pickupweapon.Player = p;
@@ -929,11 +929,11 @@ namespace DemoInfo
 				weaponPrefix = "bcc_nonlocaldata.m_hMyWeapons.";
 
 			int[] cache = new int[MAXWEAPONS];
-			
+
 			for(int i = 0; i < MAXWEAPONS; i++)
 			{
 				int iForTheMethod = i; //Because else i is passed as reference to the delegate. 
-				
+
 				playerEntity.FindProperty(weaponPrefix + i.ToString().PadLeft(3, '0')).IntRecived += (sender, e) => {
 					int index = e.Value & INDEX_MASK;
 
@@ -987,7 +987,7 @@ namespace DemoInfo
 
 					if (p.FlashHandle != null && p.FlashHandle.AmmoType == iForTheMethod) {
 						if (e.Value == 2) {
-							p.newWeapons.Enqueue(p.FlashHandle);
+							p.NewWeapons.Enqueue(p.FlashHandle);
 							p.HasTwoFlashes = true;
 						} else if (p.HasTwoFlashes) {
 							DropWeaponEventArgs dropweapon = new DropWeaponEventArgs();
@@ -1032,11 +1032,11 @@ namespace DemoInfo
 		}
 
 		private bool AttributeWeapon(int weaponEntityIndex, Player p)
-		{			
+		{
 			var weapon = weapons[weaponEntityIndex];
 			weapon.Owner = p;
 			p.rawWeapons [weaponEntityIndex] = weapon;
-			p.newWeapons.Enqueue(weapon);
+			p.NewWeapons.Enqueue(weapon);
 
 			return true;
 

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -985,8 +985,17 @@ namespace DemoInfo
 				playerEntity.FindProperty ("m_iAmmo." + i.ToString ().PadLeft (3, '0')).IntRecived += (sender, e) => {
 					p.AmmoLeft [iForTheMethod] = e.Value;
 
-					if (p.FlashHandle != null && p.FlashHandle.AmmoType == iForTheMethod && e.Value == 2) {
-						p.newWeapons.Enqueue(p.FlashHandle);
+					if (p.FlashHandle != null && p.FlashHandle.AmmoType == iForTheMethod) {
+						if (e.Value == 2) {
+							p.newWeapons.Enqueue(p.FlashHandle);
+							p.HasTwoFlashes = true;
+						} else if (p.HasTwoFlashes) {
+							DropWeaponEventArgs dropweapon = new DropWeaponEventArgs();
+							dropweapon.Player = p;
+							dropweapon.Weapon = p.FlashHandle;
+							RaiseDropWeapon(dropweapon);
+							p.HasTwoFlashes = false;
+						}
 					}
 				};
 			}

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -591,15 +591,13 @@ namespace DemoInfo
 
 					while (p.NewWeapons.Count > 0){
 						var weapon = p.NewWeapons.Dequeue();
-						if (weapon.Weapon != EquipmentElement.Knife) { 
-							PickupWeaponEventArgs pickupweapon = new PickupWeaponEventArgs();
-							pickupweapon.Player = p;
-							pickupweapon.Weapon = weapon;
-							RaisePickupWeapon(pickupweapon);
+						PickupWeaponEventArgs pickupweapon = new PickupWeaponEventArgs();
+						pickupweapon.Player = p;
+						pickupweapon.Weapon = weapon;
+						RaisePickupWeapon(pickupweapon);
 
-							if (weapon.Weapon == EquipmentElement.Flash) {
-								p.FlashHandle = weapon;
-							}
+						if (weapon.Weapon == EquipmentElement.Flash) {
+							p.FlashHandle = weapon;
 						}
 					}
 
@@ -940,13 +938,10 @@ namespace DemoInfo
 					if (index != INDEX_MASK) {
 						if(cache[iForTheMethod] != 0) //Player already has a weapon in this slot. 
 						{
-							if (p.rawWeapons[cache[iForTheMethod]].Weapon != EquipmentElement.Knife)
-							{ 
-								DropWeaponEventArgs dropweapon = new DropWeaponEventArgs();
-								dropweapon.Player = p;
-								dropweapon.Weapon = p.rawWeapons[cache[iForTheMethod]];
-								RaiseDropWeapon(dropweapon);
-							}
+							DropWeaponEventArgs dropweapon = new DropWeaponEventArgs();
+							dropweapon.Player = p;
+							dropweapon.Weapon = p.rawWeapons[cache[iForTheMethod]];
+							RaiseDropWeapon(dropweapon);
 							
 							p.rawWeapons.Remove(cache[iForTheMethod]);
 							cache[iForTheMethod] = 0;
@@ -961,13 +956,10 @@ namespace DemoInfo
 						}
 						if (p.rawWeapons.ContainsKey(cache[iForTheMethod]))
 						{
-							if (p.rawWeapons[cache[iForTheMethod]].Weapon != EquipmentElement.Knife)
-							{
-								DropWeaponEventArgs dropweapon = new DropWeaponEventArgs();
-								dropweapon.Player = p;
-								dropweapon.Weapon = p.rawWeapons[cache[iForTheMethod]];
-								RaiseDropWeapon(dropweapon);
-							}
+							DropWeaponEventArgs dropweapon = new DropWeaponEventArgs();
+							dropweapon.Player = p;
+							dropweapon.Weapon = p.rawWeapons[cache[iForTheMethod]];
+							RaiseDropWeapon(dropweapon);
 
 							p.rawWeapons.Remove(cache[iForTheMethod]);
 						}

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -207,14 +207,15 @@ namespace DemoInfo
 
 		/// <summary>
 		/// Occurs when player picks up an item, including grenades and bomb
-		/// Hint: Triggers on spawns and buys as well as picking up items off the ground
+		/// Hint: Raised on spawns and buys as well as picking up items.
 		/// </summary>
-		public event EventHandler<PickupItemEventArgs> PickupItem;
+		public event EventHandler<PickupWeaponEventArgs> PickupWeapon;
 
 		/// <summary>
 		/// Occurs when player drops a weapon, including grenades and bomb
+		/// Hint: Raised on grenade throws and player deaths as well.
 		/// </summary>
-		public event EventHandler<DropItemEventArgs> DropItem;
+		public event EventHandler<DropWeaponEventArgs> DropWeapon;
 
 		/// <summary>
 		/// Occurs when the player object is first updated to reference all the necessary information
@@ -590,11 +591,15 @@ namespace DemoInfo
 
 					while (p.newWeapons.Count > 0){
 						var weapon = p.newWeapons.Dequeue();
-						if (weapon.Weapon != EquipmentElement.Knife){ 
-							PickupItemEventArgs pickupitem = new PickupItemEventArgs();
-							pickupitem.Player = p;
-							pickupitem.Weapon = weapon;
-							RaisePickupItem(pickupitem);
+						if (weapon.Weapon != EquipmentElement.Knife) { 
+							PickupWeaponEventArgs pickupweapon = new PickupWeaponEventArgs();
+							pickupweapon.Player = p;
+							pickupweapon.Weapon = weapon;
+							RaisePickupWeapon(pickupweapon);
+
+							if (weapon.Weapon == EquipmentElement.Flash) {
+								p.FlashHandle = weapon;
+							}
 						}
 					}
 
@@ -937,10 +942,10 @@ namespace DemoInfo
 						{
 							if (p.rawWeapons[cache[iForTheMethod]].Weapon != EquipmentElement.Knife)
 							{ 
-								DropItemEventArgs dropitem = new DropItemEventArgs();
-								dropitem.Player = p;
-								dropitem.Weapon = p.rawWeapons[cache[iForTheMethod]];
-								RaiseDropItem(dropitem);
+								DropWeaponEventArgs dropweapon = new DropWeaponEventArgs();
+								dropweapon.Player = p;
+								dropweapon.Weapon = p.rawWeapons[cache[iForTheMethod]];
+								RaiseDropWeapon(dropweapon);
 							}
 							
 							p.rawWeapons.Remove(cache[iForTheMethod]);
@@ -958,10 +963,10 @@ namespace DemoInfo
 						{
 							if (p.rawWeapons[cache[iForTheMethod]].Weapon != EquipmentElement.Knife)
 							{
-								DropItemEventArgs dropitem = new DropItemEventArgs();
-								dropitem.Player = p;
-								dropitem.Weapon = p.rawWeapons[cache[iForTheMethod]];
-								RaiseDropItem(dropitem);
+								DropWeaponEventArgs dropweapon = new DropWeaponEventArgs();
+								dropweapon.Player = p;
+								dropweapon.Weapon = p.rawWeapons[cache[iForTheMethod]];
+								RaiseDropWeapon(dropweapon);
 							}
 
 							p.rawWeapons.Remove(cache[iForTheMethod]);
@@ -979,6 +984,10 @@ namespace DemoInfo
 
 				playerEntity.FindProperty ("m_iAmmo." + i.ToString ().PadLeft (3, '0')).IntRecived += (sender, e) => {
 					p.AmmoLeft [iForTheMethod] = e.Value;
+
+					if (p.FlashHandle != null && p.FlashHandle.AmmoType == iForTheMethod && e.Value == 2) {
+						p.newWeapons.Enqueue(p.FlashHandle);
+					}
 				};
 			}
 		}
@@ -1370,16 +1379,16 @@ namespace DemoInfo
 				BombAbortDefuse(this, args);
 		}
 
-		internal void RaisePickupItem(PickupItemEventArgs args)
+		internal void RaisePickupWeapon(PickupWeaponEventArgs args)
 		{
-			if (PickupItem != null)
-				PickupItem(this, args);
+			if (PickupWeapon != null)
+				PickupWeapon(this, args);
 		}
 
-		internal void RaiseDropItem(DropItemEventArgs args)
+		internal void RaiseDropWeapon(DropWeaponEventArgs args)
 		{
-			if (DropItem != null)
-				DropItem(this, args);
+			if (DropWeapon != null)
+				DropWeapon(this, args);
 		}
 
 		internal void RaiseSayText(SayTextEventArgs args)
@@ -1447,8 +1456,8 @@ namespace DemoInfo
 			this.SmokeNadeEnded = null;
 			this.SmokeNadeStarted = null;
 			this.WeaponFired = null;
-			this.DropItem = null;
-			this.PickupItem = null;
+			this.DropWeapon = null;
+			this.PickupWeapon = null;
 
 			Players.Clear ();
 		}

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -418,7 +418,7 @@ namespace DemoInfo
 			if (OriginalString.Contains ("knife") || OriginalString == "bayonet") {
 				weapon = EquipmentElement.Knife;
 			}
-			
+
 			if (weapon == EquipmentElement.Unknown) {
 				switch (OriginalString) {
 				case "ak47":

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -245,13 +245,13 @@ namespace DemoInfo
 		public Hitgroup Hitgroup { get; set; }
 	}
 
-	public class PickupItemEventArgs : EventArgs
+	public class PickupWeaponEventArgs : EventArgs
 	{
 		public Player Player { get; set; }
 		public Equipment Weapon { get; set; }
 	}
 
-	public class DropItemEventArgs : EventArgs
+	public class DropWeaponEventArgs : EventArgs
 	{
 		public Player Player { get; set; }
 		public Equipment Weapon { get; set; }

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -245,6 +245,18 @@ namespace DemoInfo
 		public Hitgroup Hitgroup { get; set; }
 	}
 
+	public class PickupItemEventArgs : EventArgs
+	{
+		public Player Player { get; set; }
+		public Equipment Weapon { get; set; }
+	}
+
+	public class DropItemEventArgs : EventArgs
+	{
+		public Player Player { get; set; }
+		public Equipment Weapon { get; set; }
+	}
+
 	public class PlayerBindEventArgs : EventArgs
 	{
 		public Player Player {get; set; }
@@ -381,6 +393,7 @@ namespace DemoInfo
 
 			this.Weapon = MapEquipment (originalString);
 
+
 		}
 
 		internal Equipment (string originalString, string skin)
@@ -405,7 +418,7 @@ namespace DemoInfo
 			if (OriginalString.Contains ("knife") || OriginalString == "bayonet") {
 				weapon = EquipmentElement.Knife;
 			}
-
+			
 			if (weapon == EquipmentElement.Unknown) {
 				switch (OriginalString) {
 				case "ak47":

--- a/DemoInfo/Player.cs
+++ b/DemoInfo/Player.cs
@@ -73,6 +73,7 @@ namespace DemoInfo
 		internal int TeamID;
 
 		internal Equipment FlashHandle;
+		internal bool HasTwoFlashes = false;
 
 		internal int[] AmmoLeft = new int[32];
 

--- a/DemoInfo/Player.cs
+++ b/DemoInfo/Player.cs
@@ -21,6 +21,7 @@ namespace DemoInfo
 
 		public int Armor { get; set; }
 
+
 		public Vector LastAlivePosition { get; set; }
 
 		public Vector Velocity { get; set; }
@@ -58,6 +59,7 @@ namespace DemoInfo
 
 		internal Dictionary<int, Equipment> rawWeapons = new Dictionary<int, Equipment>();
 		public IEnumerable<Equipment> Weapons { get { return rawWeapons.Values; } }
+		internal Queue<Equipment> newWeapons = new Queue<Equipment>();
 
 		public bool IsAlive {
 			get { return HP > 0; }

--- a/DemoInfo/Player.cs
+++ b/DemoInfo/Player.cs
@@ -21,7 +21,6 @@ namespace DemoInfo
 
 		public int Armor { get; set; }
 
-
 		public Vector LastAlivePosition { get; set; }
 
 		public Vector Velocity { get; set; }
@@ -72,6 +71,8 @@ namespace DemoInfo
 		public bool HasHelmet { get; set; }
 
 		internal int TeamID;
+
+		internal Equipment FlashHandle;
 
 		internal int[] AmmoLeft = new int[32];
 

--- a/DemoInfo/Player.cs
+++ b/DemoInfo/Player.cs
@@ -58,7 +58,7 @@ namespace DemoInfo
 
 		internal Dictionary<int, Equipment> rawWeapons = new Dictionary<int, Equipment>();
 		public IEnumerable<Equipment> Weapons { get { return rawWeapons.Values; } }
-		internal Queue<Equipment> newWeapons = new Queue<Equipment>();
+		internal Queue<Equipment> NewWeapons = new Queue<Equipment>();
 
 		public bool IsAlive {
 			get { return HP > 0; }


### PR DESCRIPTION
Adds events for when players pick up and drop weapons, grenades, and bomb as proposed in issue #117 .  This includes spawns and purchases for pickups and deaths and grenade throws for drops along with picking up and dropping weapons onto the ground or other players.

Implementation isn't as clean as I'd like.  I wanted `PickupWeapon` to have the correct player and weapon data when it is raised, but these are added in two different steps, the order of which isn't consistent and it seems the weapon can be swapped out later on in the tick anyways.  My solution was to create a separate container for new weapons and raise `PickupWeapon` at the end of `ParseNextTick`.

Raising an event on the second flashbang also required a new member variable, `FlashHandle` to track the flashbang.  The alternative was to hardcode the `AmmoType` (15) or iterate over `player.Weapons` on every ammo update and double check that a match was in fact a flashbang rather than trickery.
