### PR TITLE
Blind event

### DIFF
--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -29,6 +29,8 @@ namespace DemoInfo.DP.Handler
 		public static void Apply(GameEvent rawEvent, DemoParser parser)
 		{
 			var descriptors = parser.GEH_Descriptors;
+			//previous blind implementation
+			var blindPlayers = parser.GEH_BlindPlayers;
 
 			if (descriptors == null)
 				return;
@@ -183,20 +185,38 @@ namespace DemoInfo.DP.Handler
 				#region Nades
 			case "player_blind":
 				data = MapData(eventDescriptor, rawEvent);
-				var blindPlayer = parser.Players[(int)data["userid"]];
-				if (blindPlayer.Team != Team.Spectate) {
-					BlindEventArgs blind = new BlindEventArgs();
-					blind.Player = blindPlayer;
-					blind.Attacker = parser.Players[(int)data["attacker"]];
-					blind.FlashDuration = (float)data["blind_duration"];
 
-					parser.RaiseBlind(blind);
+				if (parser.Players.ContainsKey((int)data["userid"])) {
+					var blindPlayer = parser.Players.ContainsKey((int)data["userid"]) ? parser.Players[(int)data["userid"]] : null;
+
+					if (blindPlayer != null && blindPlayer.Team != Team.Spectate)
+					{
+						BlindEventArgs blind = new BlindEventArgs();
+						blind.Player = blindPlayer;
+						if (data.ContainsKey("attacker") && parser.Players.ContainsKey((int)data["attacker"])) {
+							blind.Attacker = parser.Players[(int)data["attacker"]];
+						} else {
+							blind.Attacker = null;
+						}
+
+						if (data.ContainsKey("blind_duration"))
+							blind.FlashDuration = (float?)data["blind_duration"];
+						else
+							blind.FlashDuration = null;
+
+						parser.RaiseBlind(blind);
+					}
+
+					//previous blind implementation
+					blindPlayers.Add(parser.Players[(int)data["userid"]]);
 				}
 
 				break;
 			case "flashbang_detonate":
 				var args = FillNadeEvent<FlashEventArgs>(MapData(eventDescriptor, rawEvent), parser);
+				args.FlashedPlayers = blindPlayers.ToArray(); //prev blind implementation
 				parser.RaiseFlashExploded(args);
+				blindPlayers.Clear(); //prev blind implementation
 				break;
 			case "hegrenade_detonate":
 				parser.RaiseGrenadeExploded(FillNadeEvent<GrenadeEventArgs>(MapData(eventDescriptor, rawEvent), parser));

--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -29,7 +29,6 @@ namespace DemoInfo.DP.Handler
 		public static void Apply(GameEvent rawEvent, DemoParser parser)
 		{
 			var descriptors = parser.GEH_Descriptors;
-			var blindPlayers = parser.GEH_BlindPlayers;
 
 			if (descriptors == null)
 				return;
@@ -183,15 +182,18 @@ namespace DemoInfo.DP.Handler
 
 				#region Nades
 			case "player_blind":
+				BlindEventArgs blind = new BlindEventArgs();
+
 				data = MapData(eventDescriptor, rawEvent);
-				if (parser.Players.ContainsKey((int)data["userid"]))
-					blindPlayers.Add(parser.Players[(int)data["userid"]]);
+				blind.Player = parser.Players[(int)data["userid"]];
+				blind.Attacker = parser.Players[(int)data["attacker"]];
+				blind.FlashDuration = (float)data["blind_duration"];
+
+				parser.RaiseBlind(blind);
 				break;
 			case "flashbang_detonate":
 				var args = FillNadeEvent<FlashEventArgs>(MapData(eventDescriptor, rawEvent), parser);
-				args.FlashedPlayers = blindPlayers.ToArray();
 				parser.RaiseFlashExploded(args);
-				blindPlayers.Clear();
 				break;
 			case "hegrenade_detonate":
 				parser.RaiseGrenadeExploded(FillNadeEvent<GrenadeEventArgs>(MapData(eventDescriptor, rawEvent), parser));

--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -182,14 +182,17 @@ namespace DemoInfo.DP.Handler
 
 				#region Nades
 			case "player_blind":
-				BlindEventArgs blind = new BlindEventArgs();
-
 				data = MapData(eventDescriptor, rawEvent);
-				blind.Player = parser.Players[(int)data["userid"]];
-				blind.Attacker = parser.Players[(int)data["attacker"]];
-				blind.FlashDuration = (float)data["blind_duration"];
+				var blindPlayer = parser.Players[(int)data["userid"]];
+				if (blindPlayer.Team != Team.Spectate) {
+					BlindEventArgs blind = new BlindEventArgs();
+					blind.Player = blindPlayer;
+					blind.Attacker = parser.Players[(int)data["attacker"]];
+					blind.FlashDuration = (float)data["blind_duration"];
 
-				parser.RaiseBlind(blind);
+					parser.RaiseBlind(blind);
+				}
+
 				break;
 			case "flashbang_detonate":
 				var args = FillNadeEvent<FlashEventArgs>(MapData(eventDescriptor, rawEvent), parser);

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -205,6 +205,11 @@ namespace DemoInfo
 		/// </summary>
 		public event EventHandler<PlayerHurtEventArgs> PlayerHurt;
 
+		/// <summary>
+		/// Occurs when player is blinded by flashbang
+		/// Hint: The order of the blind event and FlashNadeExploded event is not always the same
+		/// </summary>
+		public event EventHandler<BlindEventArgs> Blind;
 
 		/// <summary>
 		/// Occurs when the player object is first updated to reference all the necessary information
@@ -403,15 +408,6 @@ namespace DemoInfo
 		/// Luckily these contain a map ID |--> Name.
 		/// </summary>
 		internal Dictionary<int, GameEventList.Descriptor> GEH_Descriptors = null;
-
-		/// <summary>
-		/// The blind players, so we can tell who was flashed by a flashbang. 
-		/// </summary>
-		internal List<Player> GEH_BlindPlayers = new List<Player>();
-
-		// These could be Dictionary<int, RecordedPropertyUpdate[]>, but I was too lazy to
-		// define that class. Also: It doesn't matter anyways, we always have to cast.
-
 
 		/// <summary>
 		/// The preprocessed baselines, useful to create entities fast
@@ -1193,6 +1189,12 @@ namespace DemoInfo
 		{
 			if (PlayerHurt != null)
 				PlayerHurt(this, hurt);
+		}
+
+		internal void RaiseBlind(BlindEventArgs blind)
+		{
+			if (Blind != null)
+				Blind(this, blind);
 		}
 
 		internal void RaisePlayerBind(PlayerBindEventArgs bind)

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -410,6 +410,15 @@ namespace DemoInfo
 		internal Dictionary<int, GameEventList.Descriptor> GEH_Descriptors = null;
 
 		/// <summary>
+		/// The blind players, so we can tell who was flashed by a flashbang.
+		/// previous blind implementation
+		/// </summary>
+		internal List<Player> GEH_BlindPlayers = new List<Player>();
+
+		// These could be Dictionary<int, RecordedPropertyUpdate[]>, but I was too lazy to
+		// define that class. Also: It doesn't matter anyways, we always have to cast.
+
+		/// <summary>
 		/// The preprocessed baselines, useful to create entities fast
 		/// </summary>
 		internal Dictionary<int, object[]> PreprocessedBaselines = new Dictionary<int, object[]>();

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -159,6 +159,10 @@ namespace DemoInfo
 	}
 	public class FlashEventArgs : NadeEventArgs
 	{
+		//previous blind implementation
+		public Player[] FlashedPlayers { get; internal set; }
+		//
+
 		public FlashEventArgs () : base(EquipmentElement.Flash)
 		{
 
@@ -249,7 +253,7 @@ namespace DemoInfo
 
 		public Player Attacker { get; set; }
 
-		public float FlashDuration { get; set; }
+		public float? FlashDuration { get; set; }
 	}
 
 	public class PlayerBindEventArgs : EventArgs

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -159,8 +159,6 @@ namespace DemoInfo
 	}
 	public class FlashEventArgs : NadeEventArgs
 	{
-		public Player[] FlashedPlayers { get; internal set; }
-
 		public FlashEventArgs () : base(EquipmentElement.Flash)
 		{
 
@@ -243,6 +241,15 @@ namespace DemoInfo
 		/// </summary>
 		/// <value>The hitgroup.</value>
 		public Hitgroup Hitgroup { get; set; }
+	}
+
+	public class BlindEventArgs : EventArgs
+	{
+		public Player Player { get; set; }
+
+		public Player Attacker { get; set; }
+
+		public float FlashDuration { get; set; }
 	}
 
 	public class PlayerBindEventArgs : EventArgs


### PR DESCRIPTION
**This will break current usage of `FlashedPlayers`**.  If that's an issue, I can reimplement `FlashedPlayers` using the `Blind` event.  The current implementation is broken as detailed in issue #120.

This creates a new `Blind` event for when players are flashed and removes `FlashedPlayers` from `FlashEventArgs`.  Additionally, it restricts `Blind` events to players who aren't spectators.  The new `BlindEventArgs` includes an `Attacker` field, which allows a user to match `FlashEventArgs.ThrownBy` with `BlindEventArgs.Attacker`.  It also includes a `FlashDuration` field.

