### PR TITLE
Ensure that the weapon in the fire event is not null

### DIFF
--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -128,7 +128,7 @@ namespace DemoInfo.DP.Handler
 				fire.Shooter = parser.Players.ContainsKey ((int)data ["userid"]) ? parser.Players [(int)data ["userid"]] : null;
 				fire.Weapon = new Equipment ((string)data ["weapon"]);
 
-				if (fire.Shooter != null && fire.Weapon.Class != EquipmentClass.Grenade) {
+				if (fire.Shooter != null && fire.Shooter.ActiveWeapon != null && fire.Weapon.Class != EquipmentClass.Grenade) {
 					fire.Weapon = fire.Shooter.ActiveWeapon;
 				}
 


### PR DESCRIPTION
This happens if the player has no active weapon at the time of the fire event which is weird but it would make sense to fall back on the weapon value in the fire event.

Closes #127 