### PR TITLE
Associate players with molotov detonation events

### DIFF
--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -234,13 +234,21 @@ namespace DemoInfo.DP.Handler
 				parser.RaiseSmokeEnd(FillNadeEvent<SmokeEventArgs>(MapData(eventDescriptor, rawEvent), parser));
 				break;
 			case "inferno_startburn":
-				parser.RaiseFireStart(FillNadeEvent<FireEventArgs>(MapData(eventDescriptor, rawEvent), parser));
+				var fireData = MapData(eventDescriptor, rawEvent);
+				var fireArgs = FillNadeEvent<FireEventArgs>(fireData, parser);
+				var fireStarted = new Tuple<int, FireEventArgs>((int)fireData["entityid"], fireArgs);
+				parser.GEH_StartBurns.Enqueue(fireStarted);
+
 				break;
 			case "inferno_expire":
-				parser.RaiseFireEnd(FillNadeEvent<FireEventArgs>(MapData(eventDescriptor, rawEvent), parser));
+				var fireEndData = MapData(eventDescriptor, rawEvent);
+				var fireEndArgs = FillNadeEvent<FireEventArgs>(fireEndData, parser);
+				int entityID = (int)fireEndData["entityid"];
+				fireEndArgs.ThrownBy = parser.InfernoOwners[entityID];
+				parser.RaiseFireEnd(fireEndArgs);
 				break;
 				#endregion
-			
+
 			case "player_connect":
 				data = MapData (eventDescriptor, rawEvent);
 

--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -238,7 +238,7 @@ namespace DemoInfo.DP.Handler
 				var fireArgs = FillNadeEvent<FireEventArgs>(fireData, parser);
 				var fireStarted = new Tuple<int, FireEventArgs>((int)fireData["entityid"], fireArgs);
 				parser.GEH_StartBurns.Enqueue(fireStarted);
-
+				parser.RaiseFireStart(fireArgs);
 				break;
 			case "inferno_expire":
 				var fireEndData = MapData(eventDescriptor, rawEvent);

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -143,6 +143,12 @@ namespace DemoInfo
 		public event EventHandler<FireEventArgs> FireNadeStarted;
 
 		/// <summary>
+		/// FireNadeStarted, but with correct ThrownBy player.
+		/// Hint: Raised at the end of inferno_startburn tick instead of exactly when the event is parsed
+		/// </summary>
+		public EventHandler<FireEventArgs> FireNadeWithOwnerStarted;
+
+		/// <summary>
 		/// Occurs when fire nade ended.
 		/// Hint: When a round ends, this is *not* caĺled. 
 		/// Make sure to clear nades yourself at the end of rounds
@@ -593,7 +599,7 @@ namespace DemoInfo
 			while (GEH_StartBurns.Count > 0) {
 				var fireTup = GEH_StartBurns.Dequeue();
 				fireTup.Item2.ThrownBy = InfernoOwners[fireTup.Item1];
-				RaiseFireStart(fireTup.Item2);
+				RaiseFireWithOwnerStart(fireTup.Item2);
 			}
 
 			if (b) {
@@ -1322,6 +1328,15 @@ namespace DemoInfo
 				NadeReachedTarget(this, args);
 		}
 
+		internal void RaiseFireWithOwnerStart(FireEventArgs args)
+		{
+			if (FireNadeWithOwnerStarted != null)
+				FireNadeWithOwnerStarted(this, args);
+
+			if (NadeReachedTarget != null)
+				NadeReachedTarget(this, args);
+		}
+
 		internal void RaiseFireEnd(FireEventArgs args)
 		{
 			if (FireNadeEnded != null)
@@ -1444,6 +1459,7 @@ namespace DemoInfo
 			this.ExplosiveNadeExploded = null;
 			this.FireNadeEnded = null;
 			this.FireNadeStarted = null;
+			this.FireNadeWithOwnerStarted = null;
 			this.FlashNadeExploded = null;
 			this.HeaderParsed = null;
 			this.MatchStarted = null;


### PR DESCRIPTION
It turns out there was a much simpler way to do this than we realized.  the `DT_Inferno` entity is created on the same tick as the `inferno_startburn` event, but afterward, so raising the event is delayed until the end of the tick.