### PR TITLE
Better grenades

### DIFF
--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -85,11 +85,7 @@ namespace DemoInfo.DP.Handler
 			}
 
 			if (eventDescriptor.Name == "round_officially_ended")
-			{
 				parser.RaiseRoundOfficiallyEnd();
-				parser.FirstTickOfRound = true;
-			}
-
 
 			if (eventDescriptor.Name == "round_mvp") {
 				data = MapData (eventDescriptor, rawEvent);

--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -204,6 +204,9 @@ namespace DemoInfo.DP.Handler
 						else
 							blind.FlashDuration = null;
 
+						if (data.ContainsKey("entityid"))
+							blind.ProjectileEntityID = (int?)data["entityid"];
+
 						parser.RaiseBlind(blind);
 					}
 

--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -231,9 +231,13 @@ namespace DemoInfo.DP.Handler
 			case "decoy_started":
 				var decoyData = MapData(eventDescriptor, rawEvent);
 				parser.RaiseDecoyStart(FillNadeEvent<DecoyEventArgs>(decoyData, parser));
+				var idx = parser.DecoyPreStarts.FindIndex(d => d.Item1.EntityID == (int)decoyData["entityid"]);
+				parser.DecoyPreStarts.RemoveAt(idx);
 				break;
 			case "decoy_detonate":
-				parser.RaiseDecoyEnd(FillNadeEvent<DecoyEventArgs>(MapData(eventDescriptor, rawEvent), parser));
+				var decoyEndData = MapData(eventDescriptor, rawEvent);
+				parser.RaiseDecoyEnd(FillNadeEvent<DecoyEventArgs>(decoyEndData, parser));
+				parser.DetonateStarts.Remove((int)decoyEndData["entityid"]);
 				break;
 			case "smokegrenade_detonate":
 				var smokeData = MapData(eventDescriptor, rawEvent);

--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -230,9 +230,14 @@ namespace DemoInfo.DP.Handler
 				break;
 			case "decoy_started":
 				var decoyData = MapData(eventDescriptor, rawEvent);
-				parser.RaiseDecoyStart(FillNadeEvent<DecoyEventArgs>(decoyData, parser));
-				var idx = parser.DecoyPreStarts.FindIndex(d => d.Item1.EntityID == (int)decoyData["entityid"]);
-				parser.DecoyPreStarts.RemoveAt(idx);
+				var decoyArgs = FillNadeEvent<DecoyEventArgs>(decoyData, parser);
+				parser.RaiseDecoyStart(decoyArgs);
+				int decoyID = (int)decoyData["entityid"];
+				var idx = parser.DecoyPreStarts.FindIndex(d => d.Item1.EntityID == decoyID);
+				// if m_fFlags is on same tick as decoy_started, DecoyPreStarts won't have decoyID
+				if (idx != -1)
+					parser.DecoyPreStarts.RemoveAt(idx);
+				parser.DetonateStarts[decoyID] = decoyArgs;
 				break;
 			case "decoy_detonate":
 				var decoyEndData = MapData(eventDescriptor, rawEvent);

--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -421,8 +421,6 @@ namespace DemoInfo.DP.Handler
 			vec.Z = (float)data["z"];
 			nade.Position = vec;
 
-			nade.Interpolated = false;
-
 			return nade;
 		}
 

--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -85,7 +85,11 @@ namespace DemoInfo.DP.Handler
 			}
 
 			if (eventDescriptor.Name == "round_officially_ended")
-				parser.RaiseRoundOfficiallyEnd ();
+			{
+				parser.RaiseRoundOfficiallyEnd();
+				parser.FirstTickOfRound = true;
+			}
+
 
 			if (eventDescriptor.Name == "round_mvp") {
 				data = MapData (eventDescriptor, rawEvent);

--- a/DemoInfo/DT/ServerClass.cs
+++ b/DemoInfo/DT/ServerClass.cs
@@ -27,6 +27,8 @@ namespace DemoInfo.DT
 				OnNewEntity(this, new EntityCreatedEventArgs(this, e));
 		}
 
+		// On rare occasions entities are replaced rather than destroyed,
+		// in which case this event won't be raised
 		public event EventHandler<EntityDestroyedEventArgs> OnDestroyEntity;
 
 		internal void AnnounceDestroyedEntity(Entity e)

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -30,7 +30,6 @@ namespace DemoInfo
 		private const int MAX_COORD_INTEGER = 16384;
 		private int cellWidth;
 
-
 		#region Events
 		/// <summary>
 		/// Raised once when the Header of the demo is parsed

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -27,6 +27,9 @@ namespace DemoInfo
 		const int MAXPLAYERS = 64;
 		const int MAXWEAPONS = 64;
 
+		private const int MAX_COORD_INTEGER = 16384;
+		private int cellWidth;
+
 
 		#region Events
 		/// <summary>
@@ -678,6 +681,8 @@ namespace DemoInfo
 			HandlePlayers();
 
 			HandleWeapons ();
+
+			SetCellWidth();
 		}
 
 		private void HandleTeamScores()
@@ -1095,6 +1100,26 @@ namespace DemoInfo
 			};
 
 		}
+
+		private void SetCellWidth()
+		{
+			SendTableParser.FindByName("CBaseEntity").OnNewEntity += (s, baseEnt) =>
+			{
+				baseEnt.Entity.FindProperty("m_cellbits").IntRecived += (s2, bitnum) =>
+				{
+					cellWidth = 1 << bitnum.Value;
+				};
+			};
+		}
+
+		internal Vector CellsToCoords(int cellX, int cellY, int cellZ)
+		{
+			return new Vector(
+				cellX * cellWidth - MAX_COORD_INTEGER,
+				cellY * cellWidth - MAX_COORD_INTEGER,
+				cellZ * cellWidth - MAX_COORD_INTEGER);
+		}
+
 		#if SAVE_PROP_VALUES
 		[Obsolete("This method is only for debugging-purposes and shuld never be used in production, so you need to live with this warning.")]
 		public string DumpAllEntities()

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -599,12 +599,6 @@ namespace DemoInfo
 				detonate.RaiseNadeEvent();
 			}
 
-			while (newBurns.Count > 0)
-			{
-				var fire = newBurns.Dequeue();
-				RaiseFireWithOwnerStart(fire);
-			}
-
 			if (FirstTickOfRound)
 			{
 				FirstTickOfRound = false;
@@ -1153,7 +1147,6 @@ namespace DemoInfo
 		}
 
 		internal Queue<DetonateEntity> InterpDetonates = new Queue<DetonateEntity>();
-		internal Queue<FireEventArgs> newBurns = new Queue<FireEventArgs>();
 		internal List<Tuple<DetonateEntity, int>> DecoyPreStarts = new List<Tuple<DetonateEntity, int>>();
 		internal Dictionary<int, NadeEventArgs> DetonateStarts = new Dictionary<int, NadeEventArgs>();
 		private void HandleDetonates()
@@ -1170,9 +1163,15 @@ namespace DemoInfo
 
 					if (serverClass == infernoClass)
 					{
-						interpedDetonate = new DetonateEntity<FireEventArgs>(this, RaiseFireWithOwnerStart);
 						if (DetonateStarts.ContainsKey(detEntity.Entity.ID))
-							newBurns.Enqueue((FireEventArgs)DetonateStarts[detEntity.Entity.ID]);
+						{
+							// inferno_startburn successfully triggered, but we still want to add owner
+							var nadeArgs = (FireEventArgs)DetonateStarts[detEntity.Entity.ID];
+							interpedDetonate = new DetonateEntity<FireEventArgs>(this, RaiseFireWithOwnerStart, nadeArgs);
+							InterpDetonates.Enqueue((DetonateEntity)interpedDetonate);
+						}
+						else
+							interpedDetonate = new DetonateEntity<FireEventArgs>(this, RaiseFireWithOwnerStart);
 					}
 					else if (serverClass == smokeClass)
 					{

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -1213,7 +1213,6 @@ namespace DemoInfo
 					}
 				};
 			}
-
 		}
 
 		private void SetCellWidth()

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -600,18 +600,28 @@ namespace DemoInfo
 			}
 
 			// It's possible for entities to be replaced without being destroyed
-			// I have only seen this happen when the replacing class is CBaseEntity
-			// So hopefully checking the name is sufficient
+			// It might be possible for an entity to be replaced by the same type of entity,
+			// but that hasn't been seen so far.  If such a case arises, I think the only way to differentiate
+			// two entities with the same id and same class would be to look at the seriesid,
+			// but that's not currently coded.
 			if (DetonateEntities.Count > 0)
 			{
 				List<int> badEntities = new List<int>();
-				foreach (int detKey in DetonateEntities.Keys)
+				foreach (var detEnt in DetonateEntities)
 				{
-					var ent = Entities[detKey];
+					var ent = Entities[detEnt.Key];
 					if (ent != null)
 					{
-						if (ent.ServerClass.Name == "CBaseEntity")
-							badEntities.Add(detKey);
+						string detClsName = "";
+						if (detEnt.Value is FireDetonateEntity)
+							detClsName = "CInferno";
+						else if (detEnt.Value is SmokeDetonateEntity)
+							detClsName = "CSmokeGrenadeProjectile";
+						else if (detEnt.Value is DecoyDetonateEntity)
+							detClsName = "CDecoyProjectile";
+
+						if (ent.ServerClass.Name != detClsName)
+							badEntities.Add(detEnt.Key);
 					}
 				}
 

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -149,7 +149,7 @@ namespace DemoInfo
 		/// FireNadeStarted, but with correct ThrownBy player.
 		/// Hint: Raised at the end of inferno_startburn tick instead of exactly when the event is parsed
 		/// </summary>
-		public EventHandler<FireEventArgs> FireNadeWithOwnerStarted;
+		public event EventHandler<FireEventArgs> FireNadeWithOwnerStarted;
 
 		/// <summary>
 		/// Occurs when fire nade ended.
@@ -1202,13 +1202,27 @@ namespace DemoInfo
 					if (DetonateStarts.ContainsKey(detEntity.Entity.ID))
 					{
 						var nadeArgs = DetonateStarts[detEntity.Entity.ID];
-						if (nadeArgs is FireEventArgs)
-							RaiseFireEnd((FireEventArgs)nadeArgs);
-						else if (nadeArgs is SmokeEventArgs)
-							RaiseSmokeEnd((SmokeEventArgs)nadeArgs);
-						else if (nadeArgs is DecoyEventArgs)
-							RaiseDecoyEnd((DecoyEventArgs)nadeArgs);
 
+						// Make a copy of nadeArgs rather than using reference to one used for the start event
+						// Would be nice if this could be done dynamically
+						if (nadeArgs is FireEventArgs)
+						{
+							FireEventArgs newArgs = new FireEventArgs(nadeArgs);
+							newArgs.Interpolated = true;
+							RaiseFireEnd(newArgs);
+						}
+						else if (nadeArgs is SmokeEventArgs)
+						{
+							SmokeEventArgs newArgs = new SmokeEventArgs(nadeArgs);
+							newArgs.Interpolated = true;
+							RaiseSmokeEnd(newArgs);
+						}
+						else if (nadeArgs is DecoyEventArgs)
+						{
+							DecoyEventArgs newArgs = new DecoyEventArgs(nadeArgs);
+							newArgs.Interpolated = true;
+							RaiseDecoyEnd(newArgs);
+						}
 						DetonateStarts.Remove(detEntity.Entity.ID);
 					}
 				};

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -1193,7 +1193,7 @@ namespace DemoInfo
 							// decoy_started events, but m_fFlags always occurs 0-128 IngameTicks beforehand.
 							if (flag.Value == 1)
 							{
-								if (!DetonateStarts.ContainsKey(detEntity.Entity.ID))
+								if (DetonateStarts[detEntity.Entity.ID].Interpolated)
 								{
 									// It's possible for m_fFlags to be set on the same tick as decoy_started,
 									// in which case this will be parsed after the decoy_started event, hence

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -125,6 +125,9 @@ namespace DemoInfo
 		public EquipmentElement NadeType { get; internal set; }
 		public Player ThrownBy { get; internal set; }
 
+		public int? EntityID;
+		public bool Interpolated = false;
+
 		internal NadeEventArgs ()
 		{
 		

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -133,6 +133,16 @@ namespace DemoInfo
 		
 		}
 
+		internal NadeEventArgs (NadeEventArgs nadeArgs)
+		{
+			Position = nadeArgs.Position;
+			NadeType = nadeArgs.NadeType;
+			ThrownBy = nadeArgs.ThrownBy;
+
+			EntityID = nadeArgs.EntityID;
+			Interpolated = nadeArgs.Interpolated;
+		}
+
 		internal NadeEventArgs (EquipmentElement type)
 		{
 			this.NadeType = type;
@@ -145,6 +155,11 @@ namespace DemoInfo
 		{
 			
 		}
+
+		public FireEventArgs (NadeEventArgs nadeArgs) : base(nadeArgs)
+		{
+
+		}
 	}
 	public class SmokeEventArgs : NadeEventArgs
 	{
@@ -152,12 +167,22 @@ namespace DemoInfo
 		{
 			
 		}
+
+		public SmokeEventArgs (NadeEventArgs nadeArgs) : base(nadeArgs)
+		{
+
+		}
 	}
 	public class DecoyEventArgs : NadeEventArgs
 	{
 		public DecoyEventArgs () : base(EquipmentElement.Decoy)
 		{
 			
+		}
+
+		public DecoyEventArgs (NadeEventArgs nadeArgs) : base(nadeArgs)
+		{
+
 		}
 	}
 	public class FlashEventArgs : NadeEventArgs
@@ -170,12 +195,22 @@ namespace DemoInfo
 		{
 
 		}
+
+		public FlashEventArgs (NadeEventArgs nadeArgs) : base(nadeArgs)
+		{
+
+		}
 	}
 	public class GrenadeEventArgs : NadeEventArgs
 	{
 		public GrenadeEventArgs () : base(EquipmentElement.HE)
 		{
 			
+		}
+
+		public GrenadeEventArgs (NadeEventArgs nadeArgs) : base(nadeArgs)
+		{
+
 		}
 	}
 

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -125,12 +125,12 @@ namespace DemoInfo
 		public EquipmentElement NadeType { get; internal set; }
 		public Player ThrownBy { get; internal set; }
 
-		public int? EntityID;
-		public bool Interpolated = false;
+		public int? EntityID { get; internal set; }
+		public bool Interpolated { get; internal set; }
 
 		internal NadeEventArgs ()
 		{
-		
+			Interpolated = false;
 		}
 
 		internal NadeEventArgs (NadeEventArgs nadeArgs)
@@ -146,6 +146,7 @@ namespace DemoInfo
 		internal NadeEventArgs (EquipmentElement type)
 		{
 			this.NadeType = type;
+			Interpolated = false;
 		}
 	}
 

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -257,6 +257,8 @@ namespace DemoInfo
 		public Player Attacker { get; set; }
 
 		public float? FlashDuration { get; set; }
+
+		public int? ProjectileEntityID { get; set; }
 	}
 
 	public class PlayerBindEventArgs : EventArgs

--- a/DemoInfo/Structs.cs
+++ b/DemoInfo/Structs.cs
@@ -174,9 +174,17 @@ namespace DemoInfo
 		internal NadeEventArgs NadeArgs;
 		internal DetonateState DetonateState = DetonateState.PreDetonate;
 
-		// These properties keep NadeArgs current
+		// Necessary to use properties here so that NadeArgs is kept current
 		override internal int? EntityID { get { return NadeArgs.EntityID; } set { NadeArgs.EntityID = value; } }
-		override internal Vector Origin { get { return _origin; } set { _origin = value; NadeArgs.Position = Position; } } //not efficient, but the least bad option
+		override internal Vector Origin {
+			get { return _origin; }
+			set
+			{ // origin is always present in position updates
+				_origin = value;
+				if (NadeArgs.Interpolated)
+					NadeArgs.Position = Position;
+			}
+		}
 		override internal Player Owner { get { return NadeArgs.ThrownBy; } set { NadeArgs.ThrownBy = value; } }
 
 		Vector _origin;

--- a/DemoInfo/Structs.cs
+++ b/DemoInfo/Structs.cs
@@ -198,6 +198,12 @@ namespace DemoInfo
 			Raise = raise;
 		}
 
+		internal DetonateEntity(DemoParser parser, Action<T> raise, T nadeArgs) : base(parser)
+		{
+			NadeArgs = nadeArgs;
+			Raise = raise;
+		}
+
 		override internal void RaiseNadeEvent()
 		{
 			Raise((T)NadeArgs);

--- a/DemoInfo/Structs.cs
+++ b/DemoInfo/Structs.cs
@@ -129,11 +129,39 @@ namespace DemoInfo
 			return new Vector() {X = a.X - b.X, Y = a.Y - b.Y, Z = a.Z - b.Z };
 		}
 
+		public double Distance(Vector v)
+		{
+			return Math.Sqrt(Math.Pow(this.X - v.X, 2) + Math.Pow(this.Y - v.Y, 2) + Math.Pow(this.Z - v.Z, 2));
+		}
+
         public override string ToString()
         {
             return "{X: " + X + ", Y: " + Y + ", Z: " + Z + " }";
         }
     }
+
+	internal class OwnedEntity
+	{
+		internal Vector Origin;
+		internal int CellX;
+		internal int CellY;
+		internal int CellZ;
+		internal Player Owner;
+		internal Vector Position
+		{
+			get
+			{
+				return parser.CellsToCoords(CellX, CellY, CellZ) + Origin;
+			}
+		}
+
+		private DemoParser parser;
+
+		public OwnedEntity(DemoParser parser)
+		{
+			this.parser = parser;
+		}
+	}
 
 	/// <summary>
 	/// And Angle in the Source-Engine. Looks pretty much like a vector. 

--- a/DemoInfo/Structs.cs
+++ b/DemoInfo/Structs.cs
@@ -147,7 +147,7 @@ namespace DemoInfo
 		internal int CellX { get; set; }
 		internal int CellY { get; set; }
 		internal int CellZ { get; set; }
-		internal Player Owner { get; set; }
+		virtual internal Player Owner { get; set; }
 		internal Vector Position
 		{
 			get
@@ -185,7 +185,8 @@ namespace DemoInfo
 
 		// These properties keep NadeArgs current
 		override internal int? EntityID { get { return NadeArgs.EntityID; } set { NadeArgs.EntityID = value; } }
-		override internal Vector Origin { get { return _origin; } set { _origin = value; NadeArgs.Position = Position; } }
+		override internal Vector Origin { get { return _origin; } set { _origin = value; NadeArgs.Position = Position; } } //not efficient, but the least bad option
+		override internal Player Owner { get { return NadeArgs.ThrownBy; } set { NadeArgs.ThrownBy = value; } }
 
 		Vector _origin;
 
@@ -193,7 +194,6 @@ namespace DemoInfo
 		{
 			NadeArgs = new T();
 			NadeArgs.Interpolated = true;
-			NadeArgs.ThrownBy = Owner;
 
 			Raise = raise;
 		}


### PR DESCRIPTION
Most demos seem to have at least a few missing detonate events from times we would fully expect the event to be present.  This PR interpolates the detonate events by tracking their associated entities

Additions:

- Interpolate detonate starts and ends for smokes, molotovs/incendiaries, and decoys.  Interpolations are accurate to the tick for smokes and molotovs, but there's an issue with decoys (see below).
- Includes detonate ends at the end of round, which used to not be captured
- EntityID handle on NadeArgs.  This is a much more convenient way of matching detonate start and end events for a user.  This is especially true now since interpolated positions arent _perfect_, though accuracy seems to be within one cell.
- Interpolated bool added NadeArgs so that user can choose to use the position from a matching detonate event if one is interpolated and the other is uninterpolated.
- ProjectileEntityID added to blind events

Problems:
- As previously mentioned, positions aren't perfect, but they're really close
- Decoys are sketchy.  There's no property that signals the detonate start, but sometime before the detonate starts there is a flag set.  After checking ~600 demos, I've settled on a 2 second threshold between the flag and interpolating the detonate.
- It's possible for entities to be replaced rather than destroyed.  My code works as long as the entity isn't replaced by an entity with the same class, which I have yet to see in the demos I've checked.
