### PR TITLE
feat: decode int64

### DIFF
--- a/DemoInfo/DP/Entity.cs
+++ b/DemoInfo/DP/Entity.cs
@@ -112,6 +112,7 @@ namespace DemoInfo.DP
 		public FlattenedPropEntry Entry { get; private set; }
 
 		public event EventHandler<PropertyUpdateEventArgs<int>> IntRecived;
+		public event EventHandler<PropertyUpdateEventArgs<long>> Int64Received;
 		public event EventHandler<PropertyUpdateEventArgs<float>> FloatRecived;
 		public event EventHandler<PropertyUpdateEventArgs<Vector>>  VectorRecived;
 		public event EventHandler<PropertyUpdateEventArgs<string>>  StringRecived;
@@ -192,6 +193,16 @@ namespace DemoInfo.DP
 					FireDataReceived_DebugEvent(val, e);
 				}
 				break;
+			case SendPropertyType.Int64:
+				{
+					var val = PropDecoder.DecodeInt64(Entry.Prop, stream);
+					if (Int64Received != null)
+						Int64Received(this, new PropertyUpdateEventArgs<long>(val, e, this));
+
+					SaveValue(val);
+					FireDataReceived_DebugEvent(val, e);
+				}
+				break;
 			case SendPropertyType.Float:
 				{
 					var val = PropDecoder.DecodeFloat(Entry.Prop, stream);
@@ -257,6 +268,7 @@ namespace DemoInfo.DP
 		public void Destroy()
 		{
 			this.IntRecived = null;
+			this.Int64Received = null;
 			this.FloatRecived = null;
 			this.ArrayRecived = null;
 			this.StringRecived = null;
@@ -287,6 +299,13 @@ namespace DemoInfo.DP
 						e.ServerClass.Name, 
 						Entry.PropertyName, 
 						SendPropertyType.Int));
+
+			if (Int64Received != null && this.Entry.Prop.Type != SendPropertyType.Int64)
+				throw new InvalidOperationException(
+					string.Format("({0}).({1}) isn't an {2}",
+						e.ServerClass.Name,
+						Entry.PropertyName,
+						SendPropertyType.Int64));
 
 			if (FloatRecived != null && this.Entry.Prop.Type != SendPropertyType.Float)
 				throw new InvalidOperationException(
@@ -323,6 +342,7 @@ namespace DemoInfo.DP
 		{
 			foreach (var arg in captured) {
 				var intReceived = arg as RecordedPropertyUpdate<int>;
+				var int64Received = arg as RecordedPropertyUpdate<long>;
 				var floatReceived = arg as RecordedPropertyUpdate<float>;
 				var vectorReceived = arg as RecordedPropertyUpdate<Vector>;
 				var stringReceived = arg as RecordedPropertyUpdate<string>;
@@ -332,6 +352,10 @@ namespace DemoInfo.DP
 					var e = entity.Props[intReceived.PropIndex].IntRecived;
 					if (e != null)
 						e(null, new PropertyUpdateEventArgs<int>(intReceived.Value, entity, entity.Props[intReceived.PropIndex]));
+				} else if (int64Received != null) {
+					var e = entity.Props[int64Received.PropIndex].Int64Received;
+					if (e != null)
+						e(null, new PropertyUpdateEventArgs<long>(int64Received.Value, entity, entity.Props[int64Received.PropIndex]));
 				} else if (floatReceived != null) {
 					var e = entity.Props[floatReceived.PropIndex].FloatRecived;
 					if (e != null)

--- a/DemoInfo/DP/Handler/PacketEntitesHandler.cs
+++ b/DemoInfo/DP/Handler/PacketEntitesHandler.cs
@@ -121,6 +121,9 @@ namespace DemoInfo.DP.Handler
 					case SendPropertyType.Int:
 						prop.IntRecived += HandleIntRecived;
 						break;
+					case SendPropertyType.Int64:
+						prop.Int64Received += HandleInt64Received;
+						break;
 					case SendPropertyType.String:
 						prop.StringRecived += HandleStringRecived;
 						break;
@@ -137,6 +140,7 @@ namespace DemoInfo.DP.Handler
 			private void HandleVectorRecived (object sender, PropertyUpdateEventArgs<Vector> e) { Capture.Add(e.Record()); }
 			private void HandleStringRecived (object sender, PropertyUpdateEventArgs<string> e) { Capture.Add(e.Record()); }
 			private void HandleIntRecived (object sender, PropertyUpdateEventArgs<int> e) { Capture.Add(e.Record()); }
+			private void HandleInt64Received(object sender, PropertyUpdateEventArgs<long> e) { Capture.Add(e.Record()); }
 			private void HandleFloatRecived (object sender, PropertyUpdateEventArgs<float> e) { Capture.Add(e.Record()); }
 			private void HandleArrayRecived (object sender, PropertyUpdateEventArgs<object[]> e) { Capture.Add(e.Record()); }
 
@@ -152,6 +156,9 @@ namespace DemoInfo.DP.Handler
 						break;
 					case SendPropertyType.Int:
 						prop.IntRecived -= HandleIntRecived;
+						break;
+					case SendPropertyType.Int64:
+						prop.Int64Received -= HandleInt64Received;
 						break;
 					case SendPropertyType.String:
 						prop.StringRecived -= HandleStringRecived;


### PR DESCRIPTION
Hi, since the 2018.12.06 update it looks like demos now contain int64.
This PR handle int64 decoding based on the original demoinfogo code.

Tested with 2 demos from the new BR game mode and some de_ demos after the update.

It should fix #153